### PR TITLE
URL 객체 리팩토링 (seq 필드 삭제)

### DIFF
--- a/src/main/java/com/fourdays/core/model/domain/URL.java
+++ b/src/main/java/com/fourdays/core/model/domain/URL.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 @Getter
 public class URL {
 
-    private Long seq;
+    private final String urlKey;
 
     private final String protocol;
 
@@ -22,10 +22,8 @@ public class URL {
 
     private final String original;
 
-    private final String urlKey;
-
     @Builder
-    public URL(String protocol, String domain, Integer port, String path, String urlKey) {
+    public URL(String urlKey, String protocol, String domain, Integer port, String path) {
         this.protocol = protocol;
         this.domain = domain;
         this.port = port != null ? port : getPortByProtocol();
@@ -36,7 +34,9 @@ public class URL {
         validateData();
     }
 
-    public URL(String original, String urlKey) {
+    public URL(String urlKey, String original) {
+        this.urlKey = urlKey;
+
         String[] protocolAndRest = original.split("://");
         this.protocol = protocolAndRest[0];
 
@@ -68,14 +68,8 @@ public class URL {
             this.path = Optional.empty();
         }
 
-        this.urlKey = urlKey;
         this.original = original;
-
         validateData();
-    }
-
-    public void changeSeq(Long seq) {
-        this.seq = seq;
     }
 
     private void validateData() {

--- a/src/test/java/com/fourdays/core/domain/URLTest.java
+++ b/src/test/java/com/fourdays/core/domain/URLTest.java
@@ -90,7 +90,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > parameters > protocol is null")
     void constructorTest_parameters_protocolIsNull() {
-        assertThatThrownBy(() -> new URL(null, "four.days", 80, "/", Base62Encoder.encode(1L)))
+        assertThatThrownBy(() -> new URL(Base62Encoder.encode(1L), null, "four.days", 80, "/"))
                 .isInstanceOf(InvalidProtocolException.class)
                 .hasMessage("protocol is invalid. protocol=" + null);
     }
@@ -98,7 +98,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > parameters > protocol is invalid")
     void constructorTest_parameters_protocolIsInvalid() {
-        assertThatThrownBy(() -> new URL("ftp", "four.days", 80, "/", Base62Encoder.encode(1L)))
+        assertThatThrownBy(() -> new URL(Base62Encoder.encode(1L), "ftp", "four.days", 80, "/"))
                 .isInstanceOf(InvalidProtocolException.class)
                 .hasMessage("protocol is invalid. protocol=" + "ftp");
     }
@@ -106,7 +106,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > parameters > domain is null")
     void constructorTest_parameters_domainIsNull() {
-        assertThatThrownBy(() -> new URL("http", null, 80, "/", Base62Encoder.encode(1L)))
+        assertThatThrownBy(() -> new URL(Base62Encoder.encode(1L), "http", null, 80, "/"))
                 .isInstanceOf(InvalidDomainException.class)
                 .hasMessage("domain is invalid. domain=" + null);
     }
@@ -114,7 +114,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > parameters > port is negative")
     void constructorTest_parameters_portIsNegative() {
-        assertThatThrownBy(() -> new URL("http", "four.days", -1, "/", Base62Encoder.encode(1L)))
+        assertThatThrownBy(() -> new URL(Base62Encoder.encode(1L), "http", "four.days", -1, "/"))
                 .isInstanceOf(InvalidPortException.class)
                 .hasMessage("port is invalid. port=" + -1);
     }
@@ -122,7 +122,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > parameters > path is invalid")
     void constructorTest_parameters_pathIsInvalid() {
-        assertThatThrownBy(() -> new URL("http", "four.days", 80, "invalidString", Base62Encoder.encode(1L)))
+        assertThatThrownBy(() -> new URL(Base62Encoder.encode(1L), "http", "four.days", 80, "invalidString"))
                 .isInstanceOf(InvalidPathException.class)
                 .hasMessage("path is invalid. path=" + "invalidString");
     }
@@ -131,7 +131,7 @@ class URLTest {
     @DisplayName("constructor > originalString > port exists")
     void constructorTest_originalString_portExists() {
         String urlKey = Base62Encoder.encode(System.nanoTime());
-        URL url = new URL("http://four.days:8080/", urlKey);
+        URL url = new URL(urlKey, "http://four.days:8080/");
         assertThat(url.getProtocol()).isEqualTo("http");
         assertThat(url.getDomain()).isEqualTo("four.days");
         assertThat(url.getPort()).isEqualTo(8080);
@@ -144,7 +144,7 @@ class URLTest {
     @DisplayName("constructor > originalString > port not exists")
     void constructorTest_originalString_portNotExists() {
         String urlKey1 = Base62Encoder.encode(System.nanoTime());
-        URL httpUrl = new URL("http://four.days/", urlKey1);
+        URL httpUrl = new URL(urlKey1, "http://four.days/");
         assertThat(httpUrl.getProtocol()).isEqualTo("http");
         assertThat(httpUrl.getDomain()).isEqualTo("four.days");
         assertThat(httpUrl.getPort()).isEqualTo(80);
@@ -153,7 +153,7 @@ class URLTest {
         assertThat(httpUrl.getUrlKey()).isEqualTo(urlKey1);
 
         String urlKey2 = Base62Encoder.encode(System.nanoTime());
-        URL httpsUrl = new URL("https://four.days/", urlKey2);
+        URL httpsUrl = new URL(urlKey2, "https://four.days/");
         assertThat(httpsUrl.getProtocol()).isEqualTo("https");
         assertThat(httpsUrl.getDomain()).isEqualTo("four.days");
         assertThat(httpsUrl.getPort()).isEqualTo(443);
@@ -166,7 +166,7 @@ class URLTest {
     @DisplayName("constructor > originalString > path exists")
     void constructorTest_originalString_pathExists() {
         String urlKey = Base62Encoder.encode(System.nanoTime());
-        URL url = new URL("http://four.days/", urlKey);
+        URL url = new URL(urlKey, "http://four.days/");
         assertThat(url.getProtocol()).isEqualTo("http");
         assertThat(url.getDomain()).isEqualTo("four.days");
         assertThat(url.getPort()).isEqualTo(80);
@@ -179,7 +179,7 @@ class URLTest {
     @DisplayName("constructor > originalString > path not exists")
     void constructorTest_originalString_pathNotExists() {
         String urlKey = Base62Encoder.encode(System.nanoTime());
-        URL url = new URL("http://four.days", urlKey);
+        URL url = new URL(urlKey, "http://four.days");
         assertThat(url.getProtocol()).isEqualTo("http");
         assertThat(url.getDomain()).isEqualTo("four.days");
         assertThat(url.getPort()).isEqualTo(80);
@@ -191,7 +191,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > originalString > protocol is null")
     void constructorTest_originalString_protocolIsNull() {
-        assertThatThrownBy(() -> new URL("://four.days:-1/", Base62Encoder.encode(1L)))
+        assertThatThrownBy(() -> new URL(Base62Encoder.encode(1L), "://four.days:-1/"))
                 .isInstanceOf(InvalidProtocolException.class)
                 .hasMessage("protocol is invalid. protocol=" + "");
     }
@@ -199,7 +199,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > originalString > protocol is invalid")
     void constructorTest_originalString_protocolIsInvalid() {
-        assertThatThrownBy(() -> new URL("ftp://four.days:80/", Base62Encoder.encode(1L)))
+        assertThatThrownBy(() -> new URL(Base62Encoder.encode(1L), "ftp://four.days:80/"))
                 .isInstanceOf(InvalidProtocolException.class)
                 .hasMessage("protocol is invalid. protocol=" + "ftp");
     }
@@ -207,7 +207,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > originalString > domain is null")
     void constructorTest_originalString_domainIsNull() {
-        assertThatThrownBy(() -> new URL("http://", Base62Encoder.encode(1L)))
+        assertThatThrownBy(() -> new URL(Base62Encoder.encode(1L), "http://"))
                 .isInstanceOf(InvalidDomainException.class)
                 .hasMessage("domain is empty");
     }
@@ -215,7 +215,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > originalString > port is negative")
     void constructorTest_originalString_portIsNegative() {
-        assertThatThrownBy(() -> new URL("http://four.days:-1/", Base62Encoder.encode(1L)))
+        assertThatThrownBy(() -> new URL(Base62Encoder.encode(1L), "http://four.days:-1/"))
                 .isInstanceOf(InvalidPortException.class)
                 .hasMessage("port is invalid. port=" + -1);
     }
@@ -237,7 +237,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > originalString > urlKey is null")
     void constructorTest_originalString_urlKeyIsNull() {
-        assertThatThrownBy(() -> new URL("https://four.days:443/hello", null))
+        assertThatThrownBy(() -> new URL(null, "https://four.days:443/hello"))
                 .isInstanceOf(InvalidUrlKeyException.class)
                 .hasMessage("urlKey is invalid. urlKey=null");
     }
@@ -259,7 +259,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > originalString > urlKey contains '/'")
     void constructorTest_originalString_urlKeyContainsSlash() {
-        assertThatThrownBy(() -> new URL("https://four.days:443/hello", "ABCD/EFG"))
+        assertThatThrownBy(() -> new URL("ABCD/EFG", "https://four.days:443/hello"))
                 .isInstanceOf(InvalidUrlKeyException.class)
                 .hasMessage("urlKey is invalid. urlKey=ABCD/EFG");
     }
@@ -281,7 +281,7 @@ class URLTest {
     @Test
     @DisplayName("constructor > originalString > urlKey contains '+'")
     void constructorTest_originalString_urlKeyContainsPlus() {
-        assertThatThrownBy(() -> new URL("https://four.days:443/hello", "ABCD+EFG"))
+        assertThatThrownBy(() -> new URL("ABCD+EFG", "https://four.days:443/hello"))
                 .isInstanceOf(InvalidUrlKeyException.class)
                 .hasMessage("urlKey is invalid. urlKey=ABCD+EFG");
     }
@@ -303,25 +303,8 @@ class URLTest {
     @Test
     @DisplayName("constructor > originalString > urlKey contains '='")
     void constructorTest_originalString_urlKeyContainsEqual() {
-        assertThatThrownBy(() -> new URL("https://four.days:443/hello", "ABCD=EFG"))
+        assertThatThrownBy(() -> new URL("ABCD=EFG", "https://four.days:443/hello"))
                 .isInstanceOf(InvalidUrlKeyException.class)
                 .hasMessage("urlKey is invalid. urlKey=ABCD=EFG");
-    }
-
-    @Test
-    @DisplayName("changeSeq")
-    void changeSeqTest() {
-        URL url = URL.builder()
-                .protocol("https")
-                .domain("four.days")
-                .port(443)
-                .path("/")
-                .urlKey("ABCDEFG")
-                .build();
-
-        assertThat(url.getSeq()).isNull();
-
-        url.changeSeq(1L);
-        assertThat(url.getSeq()).isEqualTo(1L);
     }
 }


### PR DESCRIPTION
urlKey 필드를 id, PK로 사용하고자 seq 필드 삭제